### PR TITLE
Make sure the UPR stream returns the correct value

### DIFF
--- a/unit.py
+++ b/unit.py
@@ -463,6 +463,7 @@ class UprTestCase(ParametrizedTestCase):
             if response['opcode'] == 83:
                 assert response['status'] == SUCCESS
             if response['opcode'] == 87:
+                assert response['value'] == 'value'
                 assert response['by_seqno'] > last_by_seqno
                 last_by_seqno = response['by_seqno']
                 mutations = mutations + 1


### PR DESCRIPTION
This makes the test currently fail. This bug is tracked by http://www.couchbase.com/issues/browse/MB-9921
