### PR TITLE
MB-10411: Test correct start sequence behaviour

### DIFF
--- a/unit.py
+++ b/unit.py
@@ -538,7 +538,7 @@ class UprTestCase(ParametrizedTestCase):
         high_seqno = long(resp['value']['failovers:vb_0:0:seq'])
 
         mutations = 0
-        last_by_seqno = 0
+        last_by_seqno = 7
         start_seqno = 7
         op = self.upr_client.stream_req(
             0, 0, start_seqno, end_seqno, vb_uuid, high_seqno)
@@ -551,7 +551,7 @@ class UprTestCase(ParametrizedTestCase):
                 assert response['by_seqno'] > last_by_seqno
                 last_by_seqno = response['by_seqno']
                 mutations = mutations + 1
-        assert mutations == 4
+        assert mutations == 3
 
     """Basic upr stream request (Receives mutations/deletions)
 


### PR DESCRIPTION
The `test_stream_request_with_ops_start_sequence` test was built with
wrong assumptions of the stream request. The correct behaviour is to
not include the mutation that equals the start sequence, but to only
contain the mutations that happened _since_ the start sequence.
