### PR TITLE
CBQE-4052: fixes to auth and moxi

### DIFF
--- a/lib/mc_bin_client.py
+++ b/lib/mc_bin_client.py
@@ -39,13 +39,14 @@ class MemcachedClient(object):
 
     vbucketId = 0
 
-    def __init__(self, host='127.0.0.1', port=11211, timeout=30):
+    def __init__(self, host='127.0.0.1', port=11211, timeout=30, admin_user="cbadminbucket", admin_pass="password"):
         self.host = host
         self.port = port
         self.timeout = timeout
         self._createConn()
         self.r = random.Random()
         self.vbucket_count = 1024
+        self.sasl_auth_plain(admin_user, admin_pass)
 
     def _createConn(self):
         self.s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)

--- a/rest_client.py
+++ b/rest_client.py
@@ -40,7 +40,6 @@ class RestClient(object):
                                    'saslPassword': '',
                                    'ramQuotaMB': 256,
                                    'replicaNumber': replica,
-                                   'proxyPort': 11211,
                                    'bucketType': bucket_type,
                                    'threadsNumber': 3,
                                    'flushEnabled': 1}

--- a/statshandler.py
+++ b/statshandler.py
@@ -52,10 +52,13 @@ class Stats():
         while True:
             client = McdClient(host, port)
             try:
+                client.bucket_select("default")
                 response = client.stats()
                 # check the old style or new style (as of 4.5) results
-                if response['ep_degraded_mode'] == '0' or response['ep_degraded_mode'] == 'false':
-                    break
-            except:
+                mode = response.get('ep_degraded_mode')
+                if  mode is not None:
+                    if mode == '0' or mode == 'false':
+                        break
+            except Exception as ex:
                 pass
             time.sleep(1)

--- a/unit.py
+++ b/unit.py
@@ -136,6 +136,8 @@ class ParametrizedTestCase(unittest.TestCase):
         self.statsHandler.wait_for_warmup(self.host, self.port)
         self.dcp_client = DcpClient(self.host, self.port)
         self.mcd_client = McdClient(self.host, self.port)
+        self.mcd_client.bucket_select("default")
+        self.dcp_client.bucket_select("default")
 
     def couchbase_backend_teardown(self):
         self.dcp_client.close()


### PR DESCRIPTION
Remove use of moxi port on bucket create and do bucket select.

This test suite requires an admin user to exist.  Create one via couchbase-cli:
ouchbase-cli user-manage -c 127.0.0.1:8091 -u Administrator -p password --set --rbac-username cbadminbucket --rbac-password password --roles admin --auth-type builtin