### PR TITLE
Fix collection_stream program

### DIFF
--- a/collection_stream.py
+++ b/collection_stream.py
@@ -7,7 +7,7 @@ import lib.dcp_bin_client
 import constants
 
 def collection_stream(host, port, user, password, bucket, filterFile):
-    dcp_client = lib.dcp_bin_client.DcpClient(host, port)
+    dcp_client = lib.dcp_bin_client.DcpClient(host, port, do_auth=False)
     op = dcp_client.sasl_auth_plain(user, password)
     op = dcp_client.bucket_select(bucket)
 
@@ -18,7 +18,8 @@ def collection_stream(host, port, user, password, bucket, filterFile):
 
     print "DCP Open filter: {}".format(json)
 
-    op = dcp_client.open_producer("mystream", 0x10, json)
+    op = dcp_client.open_producer("mystream", collections=True, json=json)
+    op = dcp_client.general_control("enable_noop", "true")
     op = dcp_client.stream_req(0, 0, 0, 0xffffffffffffffff, 0)
     while op.has_response():
         response = op.next_response()


### PR DESCRIPTION
The collection_stream utility had drifted from a working state in 3 ways.

1) in 5.0 (kv_engine master) collections requires noop support
2) the DcpOpen API within pydcp had changed slightly
3) the memcache client API was forcing auth with a cbadmin user, rather than
 the one the utility specifies