### PR TITLE
PyDCP simple_dcp_client feature additions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,3 @@
 .DS_Store
 *~
 *.pyc
-.idea/*
-venv/*

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .DS_Store
 *~
 *.pyc
+.idea/*
+venv/*

--- a/lib/dcp_bin_client.py
+++ b/lib/dcp_bin_client.py
@@ -252,7 +252,7 @@ class DcpClient(MemcachedClient):
         self.__opcode_dump = control
         
     def opcode_lookup(self, opcode):
-        from memcacheConstants import DCP_Opcode_Dictionary, CMD_DCP_NOOP
+        from memcacheConstants import DCP_Opcode_Dictionary
         return DCP_Opcode_Dictionary.get(opcode, 'Unknown Opcode')
 
 

--- a/lib/dcp_bin_client.py
+++ b/lib/dcp_bin_client.py
@@ -214,6 +214,9 @@ class DcpClient(MemcachedClient):
                     # stream_req ops received during add_stream request
                     self.ack_stream_req(opaque)
 
+                elif opcode == CMD_DCP_NOOP:
+                    self.ack_dcp_noop_req(opaque)
+
             except Exception as ex:
                 print "recv_op Exception:", ex
                 if 'died' in str(ex):
@@ -230,6 +233,14 @@ class DcpClient(MemcachedClient):
                              0, 0, 0, 0,
                              len(body), opaque, 0)
         self.s.send(header + body)
+
+    def ack_dcp_noop_req(self, opaque):
+        # Added function to respond to NOOP's
+        header = struct.pack(RES_PKT_FMT,
+                             RES_MAGIC_BYTE,
+                             CMD_DCP_NOOP,
+                             0, 0, 0, 0, 0, opaque, 0)
+        self.s.sendall(header)
 
 
 class DcpStream(object):

--- a/lib/dcp_bin_client.py
+++ b/lib/dcp_bin_client.py
@@ -195,8 +195,7 @@ class DcpClient(MemcachedClient):
                     self._recvMsg()
 
                 if self.__opcode_dump:
-                    out = str(hex(opcode))
-                    print 'Opcode Dump:', out, self.opcode_lookup(out)
+                    print 'Opcode Dump:', str(hex(opcode)), self.opcode_lookup(opcode)
 
                 if opaque == op.opaque:
                     response = op.formated_response(opcode, keylen,
@@ -253,23 +252,8 @@ class DcpClient(MemcachedClient):
         self.__opcode_dump = control
         
     def opcode_lookup(self, opcode):
-        opcode_dict = {'0x50': 'CMD_OPEN',
-                       '0x51': 'CMD_ADD_STREAM',
-                       '0x52': 'CMD_CLOSE_STREAM',
-                       '0x53': 'CMD_STREAM_REQ',
-                       '0x54': 'CMD_GET_FAILOVER_LOG',
-                       '0x55': 'CMD_STREAM_END',
-                       '0x56': 'CMD_SNAPSHOT_MARKER',
-                       '0x57': 'CMD_MUTATION',
-                       '0x58': 'CMD_DELETION',
-                       '0x59': 'CMD_EXPIRATION',
-                       '0x5a': 'CMD_FLUSH',
-                       '0x5b': 'CMD_SET_VB_STATE',
-                       '0x5d': 'CMD_ACK',
-                       '0x5e': 'CMD_FLOW_CONTROL',
-                       '0x5c': 'CMD_DCP_NOOP',
-                       '0x5f': 'CMD_SYSTEM_EVENT'}
-        return opcode_dict.get(opcode, 'Unknown Opcode')
+        from memcacheConstants import DCP_Opcode_Dictionary, CMD_DCP_NOOP
+        return DCP_Opcode_Dictionary.get(opcode, 'Unknown Opcode')
 
 
 class DcpStream(object):

--- a/lib/dcp_bin_client.py
+++ b/lib/dcp_bin_client.py
@@ -11,7 +11,7 @@ class DcpClient(MemcachedClient):
     """ DcpClient implements dcp protocol using mc_bin_client as base
         for sending and receiving commands """
 
-    def __init__(self, host='127.0.0.1', port=11210, timeout=30,do_auth=True):
+    def __init__(self, host='127.0.0.1', port=11210, timeout=30, do_auth=True):
         super(DcpClient, self).__init__(host, port, timeout, do_auth=do_auth)
 
         # recv timeout
@@ -41,11 +41,11 @@ class DcpClient(MemcachedClient):
         op = OpenConsumer(name)
         return self._open(op)
 
-    def open_producer(self, name, xattr = False, delete_times = False, collections = False, json = ''):
+    def open_producer(self, name, xattr=False, delete_times=False, collections=False, json=''):
         """ opens an dcp producer connection """
         self.collections = collections
         self.delete_times = delete_times
-        op = OpenProducer(name,xattr,delete_times,collections,json)
+        op = OpenProducer(name, xattr, delete_times, collections, json)
         return self._open(op)
 
     def open_notifier(self, name):
@@ -66,7 +66,6 @@ class DcpClient(MemcachedClient):
 
         op = FlowControl(buffer_size)
         return self._handle_op(op)
-
 
     def general_control(self, key, value):
         """ sent to notify producer how much data a client is able to receive
@@ -94,7 +93,7 @@ class DcpClient(MemcachedClient):
 
         return r
 
-    def add_stream(self, vbucket, takeover = 0):
+    def add_stream(self, vbucket, takeover=0):
         """ sent to dcp-consumer to add stream on a particular vbucket.
             the takeover flag is there for completeness and is used by
             ns_server during vbucket move """
@@ -110,7 +109,7 @@ class DcpClient(MemcachedClient):
         return self._handle_op(op)
 
     def stream_req(self, vbucket, takeover, start_seqno, end_seqno,
-                       vb_uuid, snap_start = None, snap_end = None):
+                   vb_uuid, snap_start=None, snap_end=None):
         """" sent to dcp-producer to stream mutations from
              a particular vbucket.
 
@@ -126,7 +125,7 @@ class DcpClient(MemcachedClient):
              snap_end = end seqno of snapshot """
 
         op = StreamRequest(vbucket, takeover, start_seqno, end_seqno,
-                            vb_uuid, snap_start, snap_end,delete_times=self.delete_times,collections=self.collections)
+                           vb_uuid, snap_start, snap_end, delete_times=self.delete_times, collections=self.collections)
 
         response = self._handle_op(op)
 
@@ -150,13 +149,12 @@ class DcpClient(MemcachedClient):
         generator = __generator(response)
         return DcpStream(generator, vbucket)
 
-
     def get_stream(self, vbucket):
         """ for use by external clients to get stream
             associated with a particular vbucket """
         return self.streams.get(vbucket)
 
-    def _handle_op(self, op, retries = 5):
+    def _handle_op(self, op, retries=5):
         """ sends op to mcd. Then it recvs response
 
             if the received response is for another op then it will
@@ -185,14 +183,13 @@ class DcpClient(MemcachedClient):
                       op.opaque,
                       op.extras)
 
-
     def recv_op(self, op):
 
         while True:
             try:
 
-                opcode, status, opaque, cas, keylen, extlen, dtype, body =\
-                     self._recvMsg()
+                opcode, status, opaque, cas, keylen, extlen, dtype, body = \
+                    self._recvMsg()
 
                 if opaque == op.opaque:
                     response = op.formated_response(opcode, keylen,
@@ -220,14 +217,13 @@ class DcpClient(MemcachedClient):
             except Exception as ex:
                 print "recv_op Exception:", ex
                 if 'died' in str(ex):
-                    return  {'opcode'  : op.opcode,
-                             'status'  : 0xff}
+                    return {'opcode': op.opcode,
+                            'status': 0xff}
                 else:
                     return None
 
-
     def ack_stream_req(self, opaque):
-        body   = struct.pack("<QQ", 123456, 0)
+        body = struct.pack("<QQ", 123456, 0)
         header = struct.pack(REQ_PKT_FMT,
                              RES_MAGIC_BYTE,
                              CMD_STREAM_REQ,
@@ -265,15 +261,14 @@ class DcpStream(object):
         if response:
 
             if response['opcode'] in (CMD_MUTATION, CMD_DELETION):
-
                 assert int(response['vbucket']) == self.vbucket
 
-                assert 'by_seqno' in response,\
-                     "ERROR: vbucket(%s) received mutation without seqno: %s"\
-                         % (response['vbucket'], response)
-                assert response['by_seqno'] > self.last_by_seqno,\
-                     "ERROR: Out of order response on vbucket %s: %s"\
-                         % (response['vbucket'], response)
+                assert 'by_seqno' in response, \
+                    "ERROR: vbucket(%s) received mutation without seqno: %s" \
+                    % (response['vbucket'], response)
+                assert response['by_seqno'] > self.last_by_seqno, \
+                    "ERROR: Out of order response on vbucket %s: %s" \
+                    % (response['vbucket'], response)
                 self.last_by_seqno = response['by_seqno']
                 self.mutation_count += 1
 
@@ -282,11 +277,10 @@ class DcpStream(object):
 
         return response
 
-
     def has_response(self):
         return not self._ended
 
-    def run(self, to_seqno = MAX_SEQNO, retries = 20):
+    def run(self, to_seqno=MAX_SEQNO, retries=20):
 
         responses = []
 
@@ -297,8 +291,8 @@ class DcpStream(object):
 
                 if r is None:
                     retries -= 1
-                    assert retries > 0,\
-                        "ERROR: vbucket (%s) stream stopped receiving mutations "\
+                    assert retries > 0, \
+                        "ERROR: vbucket (%s) stream stopped receiving mutations " \
                         % self.vbucket
                     continue
                 # add metadata for timing analysis
@@ -317,12 +311,13 @@ class DcpStream(object):
 
         return responses
 
+
 class Operation(object):
     """ Operation Class generically represents any dcp operation providing
         default values for attributes common to each operation """
 
     def __init__(self, opcode, key='', value='',
-                 extras='', vbucket=0, opaque = None):
+                 extras='', vbucket=0, opaque=None):
         self.opcode = opcode
         self.key = key
         self.value = value
@@ -332,9 +327,10 @@ class Operation(object):
         self.queue = Queue.Queue()
 
     def formated_response(self, opcode, keylen, extlen, dtype, status, cas, body, opaque):
-        return { 'opcode' : opcode,
-                 'status' : status,
-                 'body'   : body }
+        return {'opcode': opcode,
+                'status': status,
+                'body': body}
+
 
 class Open(Operation):
     """ Open connection base class """
@@ -343,17 +339,20 @@ class Open(Operation):
         opcode = CMD_OPEN
         key = name
         extras = struct.pack(">iI", 0, flag)
-        Operation.__init__(self, opcode, key, value=json, extras = extras)
+        Operation.__init__(self, opcode, key, value=json, extras=extras)
+
 
 class OpenConsumer(Open):
     """ Open consumer spec """
+
     def __init__(self, name):
         Open.__init__(self, name, FLAG_OPEN_CONSUMER, json='')
+
 
 class OpenProducer(Open):
     """ Open producer spec """
 
-    def __init__(self, name,xattr,delete_times,collection, json):
+    def __init__(self, name, xattr, delete_times, collection, json):
         flags = FLAG_OPEN_PRODUCER
         if xattr:
             flags |= FLAG_OPEN_INCLUDE_XATTRS
@@ -363,40 +362,44 @@ class OpenProducer(Open):
             flags |= FLAG_OPEN_INCLUDE_DELETE_TIMES
         Open.__init__(self, name, flags, json)
 
+
 class OpenNotifier(Open):
     """ Open notifier spec """
+
     def __init__(self, name):
         Open.__init__(self, name, FLAG_OPEN_NOTIFIER, json='')
+
 
 class CloseStream(Operation):
     """ CloseStream spec """
 
-    def __init__(self, vbucket, takeover = 0):
+    def __init__(self, vbucket, takeover=0):
         opcode = CMD_CLOSE_STREAM
         Operation.__init__(self, opcode,
-                           vbucket = vbucket)
+                           vbucket=vbucket)
 
     def formated_response(self, opcode, keylen, extlen, dtype, status, cas, body, opaque):
-        response = { 'opcode'        : opcode,
-                     'status'        : status,
-                     'value'         : body}
+        response = {'opcode': opcode,
+                    'status': status,
+                    'value': body}
         return response
+
 
 class AddStream(Operation):
     """ AddStream spec """
 
-    def __init__(self, vbucket, takeover = 0):
+    def __init__(self, vbucket, takeover=0):
         opcode = CMD_ADD_STREAM
         extras = struct.pack(">I", takeover)
         Operation.__init__(self, opcode,
-                           extras = extras,
-                           vbucket = vbucket)
+                           extras=extras,
+                           vbucket=vbucket)
 
     def formated_response(self, opcode, keylen, extlen, status, cas, body, opaque):
-        response = { 'opcode'        : opcode,
-                     'status'        : status,
-                     'extlen'        : extlen,
-                     'value'         : body}
+        response = {'opcode': opcode,
+                    'status': status,
+                    'extlen': extlen,
+                    'value': body}
         return response
 
 
@@ -404,8 +407,8 @@ class StreamRequest(Operation):
     """ StreamRequest spec """
 
     def __init__(self, vbucket, takeover, start_seqno, end_seqno,
-                 vb_uuid, snap_start = None, snap_end = None,
-                 collections = False, delete_times = False):
+                 vb_uuid, snap_start=None, snap_end=None,
+                 collections=False, delete_times=False):
 
         if snap_start is None:
             snap_start = start_seqno
@@ -421,8 +424,8 @@ class StreamRequest(Operation):
                              snap_end)
 
         Operation.__init__(self, opcode,
-                           extras = extras,
-                           vbucket = vbucket)
+                           extras=extras,
+                           vbucket=vbucket)
         self.start_seqno = start_seqno
         self.end_seqno = end_seqno
         self.vb_uuid = vb_uuid
@@ -440,36 +443,33 @@ class StreamRequest(Operation):
         adjusted_time = 0
         conflict_resolution_mode = 0
 
-
-        version, op, op_length =struct.unpack(">BBH", extended_meta_data[0:4])
+        version, op, op_length = struct.unpack(">BBH", extended_meta_data[0:4])
 
         if op == META_ADJUSTED_TIME:
-             adjusted_time = struct.unpack(">Q", extended_meta_data[4:12])[0]
+            adjusted_time = struct.unpack(">Q", extended_meta_data[4:12])[0]
 
         elif op == META_CONFLICT_RESOLUTION_MODE:
-           conflict_resolution_mode = struct.unpack(">B", extended_meta_data[4:5])[0]
-        pos = 1 + 1 + 2 + op_length    # version field, op id + op value
-
-
+            conflict_resolution_mode = struct.unpack(">B", extended_meta_data[4:5])[0]
+        pos = 1 + 1 + 2 + op_length  # version field, op id + op value
 
         if len(extended_meta_data) > pos:
 
             # more to parse
-            op, op_length =struct.unpack(">BH", extended_meta_data[pos:pos+3])
+            op, op_length = struct.unpack(">BH", extended_meta_data[pos:pos + 3])
             pos = pos + 3
             if op == META_ADJUSTED_TIME:
-                 adjusted_time = struct.unpack(">Q", extended_meta_data[pos:pos+4])[0]
+                adjusted_time = struct.unpack(">Q", extended_meta_data[pos:pos + 4])[0]
 
             elif op == META_CONFLICT_RESOLUTION_MODE:
-               conflict_resolution_mode = struct.unpack(">B", extended_meta_data[pos:pos+1])[0]
+                conflict_resolution_mode = struct.unpack(">B", extended_meta_data[pos:pos + 1])[0]
 
         return adjusted_time, conflict_resolution_mode
 
-    def parse_extended_attributes(self,value, tot_len):
+    def parse_extended_attributes(self, value, tot_len):
         xattrs = []
         pos = 0
         while pos < tot_len:
-            xattr_len = struct.unpack('>I',value[pos:pos+4])[0]
+            xattr_len = struct.unpack('>I', value[pos:pos + 4])[0]
             pos = pos + 4
             xattr_key = ""
             xattr_value = ""
@@ -495,10 +495,10 @@ class StreamRequest(Operation):
 
         if opcode == CMD_STREAM_REQ:
 
-            response = { 'opcode' : opcode,
-                         'status' : status,
-                         'failover_log' : [],
-                         'err_msg'   : None}
+            response = {'opcode': opcode,
+                        'status': status,
+                        'failover_log': [],
+                        'err_msg': None}
 
             if status == 0:
                 assert (len(body) % 16) == 0
@@ -507,12 +507,12 @@ class StreamRequest(Operation):
                 pos = 0
                 bodylen = len(body)
                 while bodylen > pos:
-                    vb_uuid, seqno = struct.unpack(">QQ", body[pos:pos+16])
+                    vb_uuid, seqno = struct.unpack(">QQ", body[pos:pos + 16])
                     response['failover_log'].append((vb_uuid, seqno))
                     pos += 16
             elif status == 35:
 
-                seqno = struct.unpack(">II",body)
+                seqno = struct.unpack(">II", body)
                 response['seqno'] = seqno[0]
                 response['rollback'] = seqno[1]
 
@@ -521,9 +521,9 @@ class StreamRequest(Operation):
 
         elif opcode == CMD_STREAM_END:
             flags = struct.unpack(">I", body[0:4])[0]
-            response = { 'opcode'  : opcode,
-                         'vbucket' : status,
-                         'flags'   : flags }
+            response = {'opcode': opcode,
+                        'vbucket': status,
+                        'flags': flags}
 
         elif opcode == CMD_MUTATION:
             if self.collection_filtering:
@@ -534,30 +534,30 @@ class StreamRequest(Operation):
                 header_len = 31
                 by_seqno, rev_seqno, flags, exp, lock_time, ext_meta_len, nru = \
                     struct.unpack(">QQIIIHB", body[0:header_len])
-            key = body[header_len:header_len+keylen]
-            value = body[header_len+keylen: len(body)- ext_meta_len]
+            key = body[header_len:header_len + keylen]
+            value = body[header_len + keylen: len(body) - ext_meta_len]
             if ext_meta_len > 0:
-                adjusted_time, conflict_resolution_mode = self.parse_extended_meta_data(body[len(body)- ext_meta_len:])
+                adjusted_time, conflict_resolution_mode = self.parse_extended_meta_data(body[len(body) - ext_meta_len:])
             if (dtype & DATATYPE_XATTR):
-                total_xattr_len = struct.unpack('>I',value[0:4])[0]
+                total_xattr_len = struct.unpack('>I', value[0:4])[0]
                 xattrs = self.parse_extended_attributes(value[4:], total_xattr_len)
-                value = value[total_xattr_len+4:]
+                value = value[total_xattr_len + 4:]
 
-            response = { 'opcode'     : opcode,
-                         'vbucket'    : status,
-                         'by_seqno'   : by_seqno,
-                         'rev_seqno'  : rev_seqno,
-                         'flags'      : flags,
-                         'expiration' : exp,
-                         'lock_time'  : lock_time,
-                         'nmeta'      : ext_meta_len,
-                         'nru'        : nru,
-                         'key'        : key,
-                         'value'      : value,
-                         'adjusted_time': adjusted_time,
-                         'conflict_resolution_mode': conflict_resolution_mode,
-                         'xattrs'     : xattrs,
-                         'collection_len' : clen}
+            response = {'opcode': opcode,
+                        'vbucket': status,
+                        'by_seqno': by_seqno,
+                        'rev_seqno': rev_seqno,
+                        'flags': flags,
+                        'expiration': exp,
+                        'lock_time': lock_time,
+                        'nmeta': ext_meta_len,
+                        'nru': nru,
+                        'key': key,
+                        'value': value,
+                        'adjusted_time': adjusted_time,
+                        'conflict_resolution_mode': conflict_resolution_mode,
+                        'xattrs': xattrs,
+                        'collection_len': clen}
 
         elif opcode == CMD_DELETION:
             delete_time = 0
@@ -565,62 +565,63 @@ class StreamRequest(Operation):
             if self.collection_filtering or self.delete_times:
                 header_len = 21
                 by_seqno, rev_seqno, delete_time, clen = \
-                struct.unpack(">QQIB", body[0:21])
+                    struct.unpack(">QQIB", body[0:21])
             else:
                 header_len = 18
                 by_seqno, rev_seqno, ext_meta_len = \
-                struct.unpack(">QQH", body[0:18])
+                    struct.unpack(">QQH", body[0:18])
 
             print delete_time
-            key = body[header_len:header_len+keylen]
+            key = body[header_len:header_len + keylen]
 
             if ext_meta_len > 0:
                 adjusted_time, conflict_resolution_mode = \
-                    self.parse_extended_meta_data(body[len(body)- ext_meta_len:])
+                    self.parse_extended_meta_data(body[len(body) - ext_meta_len:])
 
-            response = { 'opcode'     : opcode,
-                         'vbucket'    : status,
-                         'by_seqno'   : by_seqno,
-                         'rev_seqno'  : rev_seqno,
-                         'key'        : key,
-                         'adjusted_time': adjusted_time,
-                         'conflict_resolution_mode': conflict_resolution_mode,
-                         'delete_time' : delete_time,
-                         'collection_len' : clen}
+            response = {'opcode': opcode,
+                        'vbucket': status,
+                        'by_seqno': by_seqno,
+                        'rev_seqno': rev_seqno,
+                        'key': key,
+                        'adjusted_time': adjusted_time,
+                        'conflict_resolution_mode': conflict_resolution_mode,
+                        'delete_time': delete_time,
+                        'collection_len': clen}
 
         elif opcode == CMD_SNAPSHOT_MARKER:
 
             assert len(body) == 20
-            snap_start, snap_end, flag =\
+            snap_start, snap_end, flag = \
                 struct.unpack(">QQI", body)
-            assert flag in (1,2,5,6) , "Invalid snapshot flag: %s" % flag
-            assert snap_start <= snap_end, "Snapshot start: %s > end: %s" %\
-                                                (snap_start, snap_end)
-            flag = { 1 : 'memory',
-                     2 : 'disk',
-                     5 : 'memory-checkpoint',
-                     6 : 'disk-checkpoint'}[flag]
+            assert flag in (1, 2, 5, 6), "Invalid snapshot flag: %s" % flag
+            assert snap_start <= snap_end, "Snapshot start: %s > end: %s" % \
+                                           (snap_start, snap_end)
+            flag = {1: 'memory',
+                    2: 'disk',
+                    5: 'memory-checkpoint',
+                    6: 'disk-checkpoint'}[flag]
 
-            response = { 'opcode'     : opcode,
-                         'vbucket'    : status,
-                         'snap_start_seqno' : snap_start,
-                         'snap_end_seqno'   : snap_end,
-                         'flag'   : flag }
+            response = {'opcode': opcode,
+                        'vbucket': status,
+                        'snap_start_seqno': snap_start,
+                        'snap_end_seqno': snap_end,
+                        'flag': flag}
 
         elif opcode == 0x5f:
-            seqno, event =\
+            seqno, event = \
                 struct.unpack(">QI", body[0:12])
-            key = body[12:12+keylen]
-            response = { 'opcode' : opcode,
-                         'seqno' : seqno,
-                         'event' : event,
-                         'key' : key}
+            key = body[12:12 + keylen]
+            response = {'opcode': opcode,
+                        'seqno': seqno,
+                        'event': event,
+                        'key': key}
         else:
-            response = { 'err_msg' : "(Stream Request) Unknown response",
-                         'opcode'  :  opcode,
-                         'status'  : -1 }
+            response = {'err_msg': "(Stream Request) Unknown response",
+                        'opcode': opcode,
+                        'status': -1}
 
         return response
+
 
 class GetFailoverLog(Operation):
     """ GetFailoverLog spec """
@@ -628,7 +629,7 @@ class GetFailoverLog(Operation):
     def __init__(self, vbucket):
         opcode = CMD_GET_FAILOVER_LOG
         Operation.__init__(self, opcode,
-                           vbucket = vbucket)
+                           vbucket=vbucket)
 
     def formated_response(self, opcode, keylen, extlen, dtype, status, cas, body, opaque):
 
@@ -639,14 +640,15 @@ class GetFailoverLog(Operation):
             pos = 0
             bodylen = len(body)
             while bodylen > pos:
-                vb_uuid, seqno = struct.unpack(">QQ", body[pos:pos+16])
+                vb_uuid, seqno = struct.unpack(">QQ", body[pos:pos + 16])
                 failover_log.append((vb_uuid, seqno))
                 pos += 16
 
-        response = { 'opcode'        : opcode,
-                     'status'        : status,
-                     'value'         : failover_log}
+        response = {'opcode': opcode,
+                    'status': status,
+                    'value': failover_log}
         return response
+
 
 class FlowControl(Operation):
     """ FlowControl spec """
@@ -654,18 +656,17 @@ class FlowControl(Operation):
     def __init__(self, buffer_size):
         opcode = CMD_CONTROL
         Operation.__init__(self, opcode,
-                           key = "connection_buffer_size",
-                           value = str(buffer_size))
+                           key="connection_buffer_size",
+                           value=str(buffer_size))
 
     def formated_response(self, opcode, keylen, extlen, dtype, status, cas, body, opaque):
-        response = { 'opcode'        : opcode,
-                     'status'        : status,
-                     'body'          : body}
+        response = {'opcode': opcode,
+                    'status': status,
+                    'body': body}
         return response
 
 
 class GeneralControl(Operation):
-
 
     def __init__(self, key, value):
         opcode = CMD_CONTROL
@@ -674,9 +675,9 @@ class GeneralControl(Operation):
                            value)
 
     def formated_response(self, opcode, keylen, extlen, dtype, status, cas, body, opaque):
-        response = { 'opcode'        : opcode,
-                     'status'        : status,
-                     'body'          : body}
+        response = {'opcode': opcode,
+                    'status': status,
+                    'body': body}
         return response
 
 
@@ -688,13 +689,14 @@ class Ack(Operation):
         self.nbytes = nbytes
         extras = struct.pack(">L", self.nbytes)
         Operation.__init__(self, opcode,
-                           extras = extras)
+                           extras=extras)
 
     def formated_response(self, opcode, keylen, extlen, dtype, status, cas, body, opaque):
-        response = { 'opcode'        : opcode,
-                     'status'        : status,
-                     'error'          : body}
+        response = {'opcode': opcode,
+                    'status': status,
+                    'error': body}
         return response
+
 
 class Quit(Operation):
 
@@ -703,6 +705,6 @@ class Quit(Operation):
         Operation.__init__(self, opcode)
 
     def formated_response(self, opcode, keylen, extlen, dtype, status, cas, body, opaque):
-        response = { 'opcode'        : opcode,
-                     'status'        : status}
+        response = {'opcode': opcode,
+                    'status': status}
         return response

--- a/lib/memcacheConstants.py
+++ b/lib/memcacheConstants.py
@@ -50,6 +50,24 @@ CMD_DCP_ACK          = 0x5d
 CMD_CONTROL          = 0x5e
 CMD_SYSTEM_EVENT     = 0x5f
 
+# DCP opcode dictionary
+DCP_Opcode_Dictionary = {CMD_OPEN: 'CMD_OPEN',
+                         CMD_ADD_STREAM: 'CMD_ADD_STREAM',
+                         CMD_CLOSE_STREAM: 'CMD_CLOSE_STREAM',
+                         CMD_STREAM_REQ: 'CMD_STREAM_REQ',
+                         CMD_GET_FAILOVER_LOG: 'CMD_GET_FAILOVER_LOG',
+                         CMD_STREAM_END: 'CMD_STREAM_END',
+                         CMD_SNAPSHOT_MARKER: 'CMD_SNAPSHOT_MARKER',
+                         CMD_MUTATION: 'CMD_MUTATION',
+                         CMD_DELETION: 'CMD_DELETION',
+                         CMD_EXPIRATION: 'CMD_EXPIRATION',
+                         CMD_FLUSH: 'CMD_FLUSH',
+                         CMD_SET_VB_STATE: 'CMD_SET_VB_STATE',
+                         CMD_ACK: 'CMD_ACK',
+                         CMD_FLOW_CONTROL: 'CMD_FLOW_CONTROL',
+                         CMD_DCP_NOOP: 'CMD_DCP_NOOP',
+                         CMD_SYSTEM_EVENT: 'CMD_SYSTEM_EVENT'}
+
 # SASL stuff
 CMD_SASL_LIST_MECHS = 0x20
 CMD_SASL_AUTH = 0x21

--- a/simple_dcp_client.py
+++ b/simple_dcp_client.py
@@ -211,8 +211,8 @@ def parseArguments():
     parser.add_argument("--delete_times", help="Include delete times", default=False, required=False,
                         action="store_true")
     parser.add_argument("--compression", '-y', help="Compression", required=False, action='count', default=0)
-    parser.add_argument("--timeout", '-t', help="Set timeout length, -1 forces persistence", required=False, default=5)
-    parser.add_argument("--noop-interval", help="Set time in s between NOOP requests", required=False, default=120)
+    parser.add_argument("--timeout", '-t', help="Set timeout length in seconds, -1 disables timeout", required=False, default=5)
+    parser.add_argument("--noop-interval", help="Set time in seconds between NOOP requests", required=False, default=120)
     parser.add_argument("--opcode-dump", help="Dump all the received opcodes via print", required=False,
                         action="store_true")
     parser.add_argument("-u", "--user", help="User", required=True)

--- a/simple_dcp_client.py
+++ b/simple_dcp_client.py
@@ -168,6 +168,9 @@ def initiate_connection(args):
     assert response2['status'] == SUCCESS
     print "NOOP interval set to ", noop_interval
 
+    if args.opcode_dump:
+        dcp_client.opcode_dump_control(True)
+
     if force_compression:
         response = dcp_client.general_control("force_value_compression", "true")
         assert response['status'] == SUCCESS
@@ -210,6 +213,8 @@ def parseArguments():
     parser.add_argument("--compression", '-y', help="Compression", required=False, action='count', default=0)
     parser.add_argument("--timeout", '-t', help="Set timeout length, -1 forces persistence", required=False, default=5)
     parser.add_argument("--noop-interval", help="Set time in s between NOOP requests", required=False, default=120)
+    parser.add_argument("--opcode-dump", help="Dump all the received opcodes via print", required=False,
+                        action="store_true")
     parser.add_argument("-u", "--user", help="User", required=True)
     parser.add_argument("-p", "--password", help="Password", required=True)
     return parser.parse_args()

--- a/simple_dcp_client.py
+++ b/simple_dcp_client.py
@@ -129,6 +129,7 @@ def initiate_connection(args):
     timeout = int(args.timeout)
     if timeout == -1:
         timeout = 86400  # some very large number (one day)
+    noop_interval = str(args.noop_interval)
     global dcp_client
     dcp_client = DcpClient(host, int(port), timeout=timeout, do_auth=False)
     print 'Connected to:', node
@@ -162,6 +163,10 @@ def initiate_connection(args):
     response = dcp_client.general_control("enable_noop", "true")
     assert response['status'] == SUCCESS
     print "Enabled NOOP"
+
+    response2 = dcp_client.general_control("set_noop_interval", noop_interval)
+    assert response2['status'] == SUCCESS
+    print "NOOP interval set to ", noop_interval
 
     if force_compression:
         response = dcp_client.general_control("force_value_compression", "true")
@@ -204,6 +209,7 @@ def parseArguments():
                         action="store_true")
     parser.add_argument("--compression", '-y', help="Compression", required=False, action='count', default=0)
     parser.add_argument("--timeout", '-t', help="Set timeout length, -1 forces persistence", required=False, default=5)
+    parser.add_argument("--noop-interval", help="Set time in s between NOOP requests", required=False, default=120)
     parser.add_argument("-u", "--user", help="User", required=True)
     parser.add_argument("-p", "--password", help="Password", required=True)
     return parser.parse_args()

--- a/simple_dcp_client.py
+++ b/simple_dcp_client.py
@@ -126,8 +126,11 @@ def initiate_connection(args):
     filter_file = args.filter
     filter_json = ''
     host, port = args.node.split(":")
+    timeout = int(args.timeout)
+    if timeout == -1:
+        timeout = 86400  # some very large number (one day)
     global dcp_client
-    dcp_client = DcpClient(host, int(port), timeout=5, do_auth=False)
+    dcp_client = DcpClient(host, int(port), timeout=timeout, do_auth=False)
     print 'Connected to:', node
 
     try:
@@ -200,6 +203,7 @@ def parseArguments():
     parser.add_argument("--delete_times", help="Include delete times", default=False, required=False,
                         action="store_true")
     parser.add_argument("--compression", '-y', help="Compression", required=False, action='count', default=0)
+    parser.add_argument("--timeout", '-t', help="Set timeout length, -1 forces persistence", required=False, default=5)
     parser.add_argument("-u", "--user", help="User", required=True)
     parser.add_argument("-p", "--password", help="Password", required=True)
     return parser.parse_args()

--- a/simple_dcp_client.py
+++ b/simple_dcp_client.py
@@ -129,7 +129,6 @@ def initiate_connection(args):
     timeout = int(args.timeout)
     if timeout == -1:
         timeout = 86400  # some very large number (one day)
-    noop_interval = str(args.noop_interval)
     global dcp_client
     dcp_client = DcpClient(host, int(port), timeout=timeout, do_auth=False)
     print 'Connected to:', node
@@ -164,9 +163,11 @@ def initiate_connection(args):
     assert response['status'] == SUCCESS
     print "Enabled NOOP"
 
-    response2 = dcp_client.general_control("set_noop_interval", noop_interval)
-    assert response2['status'] == SUCCESS
-    print "NOOP interval set to ", noop_interval
+    if args.noop_interval:
+        noop_interval = str(args.noop_interval)
+        response2 = dcp_client.general_control("set_noop_interval", noop_interval)
+        assert response2['status'] == SUCCESS
+        print "NOOP interval set to ", noop_interval
 
     if args.opcode_dump:
         dcp_client.opcode_dump_control(True)
@@ -211,8 +212,9 @@ def parseArguments():
     parser.add_argument("--delete_times", help="Include delete times", default=False, required=False,
                         action="store_true")
     parser.add_argument("--compression", '-y', help="Compression", required=False, action='count', default=0)
-    parser.add_argument("--timeout", '-t', help="Set timeout length in seconds, -1 disables timeout", required=False, default=5)
-    parser.add_argument("--noop-interval", help="Set time in seconds between NOOP requests", required=False, default=120)
+    parser.add_argument("--timeout", '-t', help="Set timeout length in seconds, -1 disables timeout", required=False,
+                        default=5)
+    parser.add_argument("--noop-interval", help="Set time in seconds between NOOP requests", required=False)
     parser.add_argument("--opcode-dump", help="Dump all the received opcodes via print", required=False,
                         action="store_true")
     parser.add_argument("-u", "--user", help="User", required=True)


### PR DESCRIPTION
Details are contained within the commits but as an overview:
- Re-formatted files to PEP 8 standards

- Added new arguments:
-> Timeout - Sets DCPClient timeout length, also allows persistence
-> NOOP interval - Sets length between DCPClient NOOP requests
-> Opcode dump - prints opcodes and names received by the client 

- Implemented NOOP acknowledgement 