### PR TITLE
Added two tier vbucket stream timeout

### DIFF
--- a/simple_dcp_client.md
+++ b/simple_dcp_client.md
@@ -3,6 +3,8 @@
 This Python script pretends to be a DCP client, to be used for testing purposes.
 
 ### Usage:
+Currently only python2 supported.
+
 In a terminal:
 ```
 cd /path/to/pydcp
@@ -24,7 +26,7 @@ python simple_dcp_client.py <arguments>
 * Delete times `--delete_times` Include delete times in stream
 * Compression `--compression`
 * Timeout `--timeout, -t` Sets the vbucket connection timeout length in seconds. `-t -1` disables timeout
-* Vb Stream Timeout `--vb-stream-timeout` Controls the number of times a vb stream connection is repeated without receiving any activity (updates, deletions, NOOPs etc) before it is closed completely. Defaults to 0
+* Retry limit `--retry-limit` Controls the number of times a vb stream connection is repeated without receiving any activity (updates, deletions, NOOPs etc) before it is closed completely. Defaults to 0
 * NOOP Interval `--noop-interval` Sets the time in seconds between NOOP requests from the server
 * Opcode Dump `--opcode-dump` Dumps all the received opcodes via print
 * Stream Request Info `--stream-req-info` Displays the vbuckets, sequence numbers and UUIDs on every stream request


### PR DESCRIPTION
This addition includes an argument to offer the vb_streams a number
of second chances without receiving any data before their connection
is fully terminated. This is controlled with --vb-stream-timeout.
This is a simpler change, but the real question is how important/useful
it is for the improvement of simple_dcp_client

The main idea behind implementing this was to offer an option to catch
data that reached a vbucket after a timeout had already happened for
that vbucket. This could potentially be seen as unnecessary as the 
chances of this occurring aren't high, but to add to a robust testsuite
this may be a useful option.