### PR TITLE
Fix simple_dcp_client python version compatibility

### DIFF
--- a/simple_dcp_client.py
+++ b/simple_dcp_client.py
@@ -308,7 +308,7 @@ def initialise_cluster_connections(args):
         port = config_json['nodesExt'][index]['services'].get('kv')
 
         if port is not None:
-            temp_args.node = '{}:{}'.format(host, port)
+            temp_args.node = '{0}:{1}'.format(host, port)
             if 'thisNode' in config_json['nodesExt'][index]:
                 dcp_client_dict[index] = {'stream': init_dcp_client,
                                           'node': temp_args.node}


### PR DESCRIPTION
2.6 and other versions of python require format to have numbered
elements