### PR TITLE
MB-26907: Auto enable delete times when requesting enable expiry

### DIFF
--- a/simple_dcp_client.py
+++ b/simple_dcp_client.py
@@ -524,6 +524,9 @@ def parseArguments():
     if parsed_args.retry_limit and not parsed_args.timeout:
         print 'Note: It is recommended that you set a shorter vbucket timeout (via -t or --timeout) \
         when using --retry-limit'
+    if parsed_args.enable_expiry and not parsed_args.delete_times:
+        parsed_args.delete_times = True
+        print "Note: Automatically turning on delete times due to requested usage of expiry output"
     return parsed_args
 
 


### PR DESCRIPTION
This patch adds a check in the arguments so that if --enable-expiry
is requested without --delete_times, delete times is automatically
enabled along with a message that this has occurred. This is because
delete times is required to successfully retrieve expirations.