### PR TITLE
collections: DCP Stream-ID server to client support

### DIFF
--- a/lib/mc_bin_client.py
+++ b/lib/mc_bin_client.py
@@ -826,3 +826,5 @@ def error_to_str(errno):
         return "Invalid combinations of commands"
     elif errno == memcacheConstants.ERR_SUBDOC_MULTI_PATH_FAILURE:
         return "Specified key was successfully found, but one or more path operations failed"
+    elif errno == 0x8d:
+        return "Invalid use of stream-ID or no stream-ID when required"

--- a/stream_id.json
+++ b/stream_id.json
@@ -1,0 +1,7 @@
+{
+    "streams":[
+        {"collections" : ["0"], "sid":2},
+        {"collections" : ["9"], "sid":3},
+        {"scope" : ["8"], "sid":4}
+    ]
+}


### PR DESCRIPTION
Allow many streams to be created by use of the filter JSON
storing many filters, one per stream.

See stream_id.json for example