### PR TITLE
simple_dcp_client: Make explicit is written in python2

### DIFF
--- a/simple_dcp_client.md
+++ b/simple_dcp_client.md
@@ -8,7 +8,7 @@ Currently only python2 supported.
 In a terminal:
 ```
 cd /path/to/pydcp
-python simple_dcp_client.py <arguments>
+./simple_dcp_client.py <arguments>
 ```
 ##### Arguments:
 * Username `-u` Username for creating the DCP connection

--- a/simple_dcp_client.py
+++ b/simple_dcp_client.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import argparse
 import copy


### PR DESCRIPTION
Modify the hashbang of simple_dcp_client.py to explicitly state 'python2' given it is written in Python 2 and does *not* currently work with Python3.